### PR TITLE
Specify a runtime entry-point command

### DIFF
--- a/org.hdfgroup.HDFView.yml
+++ b/org.hdfgroup.HDFView.yml
@@ -14,6 +14,7 @@ finish-args:
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
+command: hdfview
 modules:
   - name: openjdk
     buildsystem: simple


### PR DESCRIPTION
Fixes the flatpak-builder-lint "toplevel-no-command" error.