### PR TITLE
Update OpenJDK to JDK version 20

### DIFF
--- a/org.hdfgroup.HDFView.yml
+++ b/org.hdfgroup.HDFView.yml
@@ -1,12 +1,12 @@
 app-id: org.hdfgroup.HDFView
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: "22.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk
 build-options:
   env:
-    JAVA_HOME: /usr/lib/sdk/openjdk/jvm/openjdk-17
+    JAVA_HOME: /usr/lib/sdk/openjdk/jvm/openjdk-20
     ANT_HOME: /usr/lib/sdk/openjdk/ant
 finish-args:
   - --env=PATH=/app/bin:/app/jre/bin:/usr/bin


### PR DESCRIPTION
Requires org.freedesktop.Platform//22.08.

https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk/tree/branch/22.08