### PR TITLE
Build SZIP support with libaec version 1.1.2

### DIFF
--- a/org.hdfgroup.HDFView.yml
+++ b/org.hdfgroup.HDFView.yml
@@ -20,10 +20,29 @@ modules:
     buildsystem: simple
     build-commands:
       - /usr/lib/sdk/openjdk/install.sh
+  - name: libaec
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DBUILD_TESTING:BOOL=OFF
+    sources:
+      - type: archive
+        url: https://gitlab.dkrz.de/k202009/libaec/-/archive/v1.1.2/libaec-v1.1.2.tar.bz2
+        sha256: bdad8c7923537c3695327aa85afdcd714fb3d30a5f956a27ba2971ef98c043ac
+        strip-components: 1
+    cleanup:
+      - /bin
+      - /include
+      - /lib/libaec.a
+      - /lib/libaec.so*
+      - /lib/libsz.a
+      - /cmake
   - name: hdf4
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
+      - -DHDF4_ENABLE_SZIP_SUPPORT:BOOL=ON
+      - -DHDF4_ENABLE_Z_LIB_SUPPORT:BOOL=ON
       - -DHDF4_BUILD_FORTRAN:BOOL=OFF
       - -DHDF4_BUILD_JAVA:BOOL=ON
       - -DHDF4_BUILD_TOOLS:BOOL=OFF
@@ -53,7 +72,8 @@ modules:
     config-opts:
       - -DHDF5_ENABLE_PARALLEL:BOOL=OFF
       - -DHDF5_ENABLE_THREADSAFE:BOOL=OFF
-      - -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=OFF
+      - -DHDF5_ENABLE_SZIP_SUPPORT:BOOL=ON
+      - -DHDF5_ENABLE_Z_LIB_SUPPORT:BOOL=ON
       - -DHDF5_BUILD_HL_LIB:BOOL=OFF
       - -DHDF5_BUILD_CPP_LIB:BOOL=OFF
       - -DHDF5_BUILD_FORTRAN:BOOL=OFF


### PR DESCRIPTION
https://gitlab.dkrz.de/k202009/libaec/-/releases/v1.1.2
https://support.hdfgroup.org/doc_resource/SZIP