### PR TITLE
Update OpenJDK to JDK version 21

### DIFF
--- a/org.hdfgroup.HDFView.yml
+++ b/org.hdfgroup.HDFView.yml
@@ -1,12 +1,12 @@
 app-id: org.hdfgroup.HDFView
 runtime: org.freedesktop.Platform
-runtime-version: "22.08"
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk
 build-options:
   env:
-    JAVA_HOME: /usr/lib/sdk/openjdk/jvm/openjdk-20
+    JAVA_HOME: /usr/lib/sdk/openjdk/jvm/openjdk-21
     ANT_HOME: /usr/lib/sdk/openjdk/ant
 finish-args:
   - --env=PATH=/app/bin:/app/jre/bin:/usr/bin


### PR DESCRIPTION
Requires org.freedesktop.Platform//23.08.

https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk/tree/branch/23.08